### PR TITLE
Fix zeros stripped in conversion from numeric

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
@@ -51,7 +51,7 @@ extension String: PostgreSQLDataConvertible {
                         integer += offset == 0 ? string : String(repeating: "0", count: 4 - string.count) + string
                     } else {
                         // Leading zeros matter with fractional
-                        fractional += fractional.count == 0 ? String(repeating: "0", count: 4 - string.count) + string : string
+                        fractional += String(repeating: "0", count: 4 - string.count) + string
                     }
                 }
                 

--- a/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
@@ -37,7 +37,7 @@ extension String: PostgreSQLDataConvertible {
                         value = value.advanced(by: 2)
                     }
                     
-                    /// conver the current char to its string form
+                    /// convert the current char to its string form
                     let string: String
                     if char == 0 {
                         /// 0 means 4 zeros

--- a/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
@@ -48,7 +48,7 @@ extension String: PostgreSQLDataConvertible {
                     
                     /// depending on our offset, append the string to before or after the decimal point
                     if offset < metadata.weight.bigEndian + 1 {
-                        integer += string
+                        integer += offset == 0 ? string : String(repeating: "0", count: 4 - string.count) + string
                     } else {
                         // Leading zeros matter with fractional
                         fractional += fractional.count == 0 ? String(repeating: "0", count: 4 - string.count) + string : string


### PR DESCRIPTION
Fixes a bug causing zeros to be stripped from numeric values such as 10234, producing 1234.